### PR TITLE
Tiny cleanup #3

### DIFF
--- a/akkeeper/src/main/scala/akkeeper/api/CommonApi.scala
+++ b/akkeeper/src/main/scala/akkeeper/api/CommonApi.scala
@@ -36,18 +36,14 @@ case class OperationFailed(requestId: RequestId, cause: Throwable) extends WithR
 trait CommonApiJsonProtocol extends DefaultJsonProtocol with RequestIdJsonProtocol {
 
   implicit val operationFailedWriter = new RootJsonWriter[OperationFailed] {
-    override def write(obj: OperationFailed): JsValue = {
-      val requestIdField = obj.requestId.toJson
-      val messageField = JsString(obj.cause.getMessage)
-      val stackTraceField = JsArray(
-        obj.cause.getStackTrace.map(s => JsString(s.toString)): _*
-      )
+    override def write(obj: OperationFailed): JsValue =
       JsObject(
-        "requestId" -> requestIdField,
-        "message" -> messageField,
-        "stackTrace" -> stackTraceField
+        "requestId" -> obj.requestId.toJson,
+        "message" -> JsString(obj.cause.getMessage),
+        "stackTrace" -> JsArray(
+          obj.cause.getStackTrace.map(s => JsString(s.toString)): _*
+        )
       )
-    }
   }
 }
 

--- a/akkeeper/src/main/scala/akkeeper/api/ContainerApi.scala
+++ b/akkeeper/src/main/scala/akkeeper/api/ContainerApi.scala
@@ -151,19 +151,18 @@ case class ContainerDeleted(requestId: RequestId, name: String) extends Containe
 trait ContainerApiJsonProtocol extends DefaultJsonProtocol
   with RequestIdJsonProtocol with ContainerDefinitionJsonProtocol {
 
-  implicit val createContainerFormat = AutoRequestIdFormat(jsonFormat2(CreateContainer.apply))
-  implicit val updateContainerFormat = AutoRequestIdFormat(jsonFormat2(UpdateContainer.apply))
-  implicit val getContainerFormat = AutoRequestIdFormat(jsonFormat2(GetContainer.apply))
-  implicit val getContainersFormat = AutoRequestIdFormat(jsonFormat1(GetContainers.apply))
-  implicit val deleteContainersFormat = AutoRequestIdFormat(jsonFormat2(DeleteContainer.apply))
+  implicit val createContainerFormat = AutoRequestIdFormat(jsonFormat2(CreateContainer))
+  implicit val updateContainerFormat = AutoRequestIdFormat(jsonFormat2(UpdateContainer))
+  implicit val getContainerFormat = AutoRequestIdFormat(jsonFormat2(GetContainer))
+  implicit val getContainersFormat = AutoRequestIdFormat(jsonFormat1(GetContainers))
+  implicit val deleteContainersFormat = AutoRequestIdFormat(jsonFormat2(DeleteContainer))
 
-  implicit val containersListFormat = jsonFormat2(ContainersList.apply)
-  implicit val containersGetResultFormat = jsonFormat2(ContainerGetResult.apply)
-  implicit val containerNotFoundFormat = jsonFormat2(ContainerNotFound.apply)
-  implicit val containerAlreadyExistsFormat = jsonFormat2(ContainerAlreadyExists.apply)
-  implicit val containerCreatedFormat = jsonFormat2(ContainerCreated.apply)
-  implicit val containerUpdatedFormat = jsonFormat2(ContainerUpdated.apply)
-  implicit val containerDeletedFormat = jsonFormat2(ContainerDeleted.apply)
+  implicit val containersListFormat = jsonFormat2(ContainersList)
+  implicit val containersGetResultFormat = jsonFormat2(ContainerGetResult)
+  implicit val containerNotFoundFormat = jsonFormat2(ContainerNotFound)
+  implicit val containerAlreadyExistsFormat = jsonFormat2(ContainerAlreadyExists)
+  implicit val containerCreatedFormat = jsonFormat2(ContainerCreated)
+  implicit val containerUpdatedFormat = jsonFormat2(ContainerUpdated)
+  implicit val containerDeletedFormat = jsonFormat2(ContainerDeleted)
 }
 
-object ContainerApiJsonProtocol extends ContainerApiJsonProtocol

--- a/akkeeper/src/main/scala/akkeeper/api/DeploymentApi.scala
+++ b/akkeeper/src/main/scala/akkeeper/api/DeploymentApi.scala
@@ -55,8 +55,7 @@ case class SubmittedInstances(requestId: RequestId, containerName: String,
 trait DeployApiJsonProtocol extends DefaultJsonProtocol
   with RequestIdJsonProtocol with InstanceIdJsonProtocol {
 
-  implicit val deployContainerFormat = AutoRequestIdFormat(jsonFormat5(DeployContainer.apply))
-  implicit val deployedInstancesFormat = jsonFormat3(SubmittedInstances.apply)
+  implicit val deployContainerFormat = AutoRequestIdFormat(jsonFormat5(DeployContainer))
+  implicit val deployedInstancesFormat = jsonFormat3(SubmittedInstances)
 }
 
-object DeployApiJsonProtocol extends DeployApiJsonProtocol

--- a/akkeeper/src/main/scala/akkeeper/api/MonitoringApi.scala
+++ b/akkeeper/src/main/scala/akkeeper/api/MonitoringApi.scala
@@ -122,15 +122,13 @@ trait MonitoringApiJsonProtocol extends DefaultJsonProtocol
   with InstanceIdJsonProtocol with RequestIdJsonProtocol
   with InstanceStatusJsonProtocol {
 
-  implicit val getInstanceFormat = AutoRequestIdFormat(jsonFormat2(GetInstance.apply))
-  implicit val getInstancesFormat = AutoRequestIdFormat(jsonFormat1(GetInstances.apply))
-  implicit val getInstancesByFormat = AutoRequestIdFormat(jsonFormat3(GetInstancesBy.apply))
-  implicit val terminateInstancesFormat = AutoRequestIdFormat(jsonFormat2(TerminateInstance.apply))
+  implicit val getInstanceFormat = AutoRequestIdFormat(jsonFormat2(GetInstance))
+  implicit val getInstancesFormat = AutoRequestIdFormat(jsonFormat1(GetInstances))
+  implicit val getInstancesByFormat = AutoRequestIdFormat(jsonFormat3(GetInstancesBy))
+  implicit val terminateInstancesFormat = AutoRequestIdFormat(jsonFormat2(TerminateInstance))
 
-  implicit val instanceInfoResponseFormat = jsonFormat2(InstanceInfoResponse.apply)
-  implicit val instanceListFormat = jsonFormat2(InstancesList.apply)
-  implicit val instanceNotFoundFormat = jsonFormat2(InstanceNotFound.apply)
-  implicit val instanceTerminatedFormat = jsonFormat2(InstanceTerminated.apply)
+  implicit val instanceInfoResponseFormat = jsonFormat2(InstanceInfoResponse)
+  implicit val instanceListFormat = jsonFormat2(InstancesList)
+  implicit val instanceNotFoundFormat = jsonFormat2(InstanceNotFound)
+  implicit val instanceTerminatedFormat = jsonFormat2(InstanceTerminated)
 }
-
-object MonitoringApiJsonProtocol extends MonitoringApiJsonProtocol

--- a/akkeeper/src/main/scala/akkeeper/common/InstanceId.scala
+++ b/akkeeper/src/main/scala/akkeeper/common/InstanceId.scala
@@ -25,12 +25,11 @@ import spray.json._
   *                      belongs to.
   * @param uuid the unique ID of the instance.
   */
-case class InstanceId(containerName: String, uuid: UUID) {
+case class InstanceId(containerName: String, uuid: UUID = UUID.randomUUID()) {
   override def toString: String = containerName + "-" + uuid.toString
 }
 
 object InstanceId {
-  def apply(containerName: String): InstanceId = InstanceId(containerName, UUID.randomUUID())
   def fromString(str: String): InstanceId = {
     val split = str.split("-", 2)
     val (containerName, uuid) = (split(0), split(1))

--- a/akkeeper/src/main/scala/akkeeper/common/LaunchMode.scala
+++ b/akkeeper/src/main/scala/akkeeper/common/LaunchMode.scala
@@ -19,9 +19,7 @@ private[akkeeper] sealed abstract class LaunchMode(val value: String)
 private[akkeeper] case object YarnLaunchMode extends LaunchMode("yarn")
 
 private[akkeeper] object LaunchMode {
-  def fromString(str: String): LaunchMode = {
-    str match {
-      case YarnLaunchMode.value => YarnLaunchMode
-    }
+  def fromString(str: String): LaunchMode = str match {
+    case YarnLaunchMode.value => YarnLaunchMode
   }
 }

--- a/akkeeper/src/main/scala/akkeeper/common/RequestId.scala
+++ b/akkeeper/src/main/scala/akkeeper/common/RequestId.scala
@@ -22,22 +22,16 @@ import spray.json._
   *
   * @param uuid the unique ID.
   */
-case class RequestId(uuid: UUID) {
+case class RequestId(uuid: UUID = UUID.randomUUID()) {
   override def toString: String = uuid.toString
-}
-
-object RequestId {
-  def apply(): RequestId = RequestId(UUID.randomUUID())
 }
 
 trait RequestIdJsonProtocol extends DefaultJsonProtocol {
   implicit val requestIdFormat = new JsonFormat[RequestId] {
-    override def write(obj: RequestId): JsValue = {
-      JsString(obj.toString)
-    }
-    override def read(json: JsValue): RequestId = {
-      RequestId(UUID.fromString(json.convertTo[String]))
-    }
+
+    override def write(obj: RequestId): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): RequestId = RequestId(UUID.fromString(json.convertTo[String]))
   }
 }
 

--- a/akkeeper/src/main/scala/akkeeper/master/service/DeployService.scala
+++ b/akkeeper/src/main/scala/akkeeper/master/service/DeployService.scala
@@ -27,7 +27,7 @@ private[akkeeper] class DeployService(deployClient: DeployClient.Async,
                                       monitoringService: ActorRef) extends RequestTrackingService {
 
   private implicit val dispatcher = context.dispatcher
-  override protected val trackedMessages: List[Class[_]] = List(classOf[DeployContainer])
+  override protected val trackedMessages: Set[Class[_]] = Set(classOf[DeployContainer])
 
   private def deployInstances(request: DeployContainer,
                               container: ContainerDefinition): SubmittedInstances = {

--- a/akkeeper/src/main/scala/akkeeper/master/service/MonitoringService.scala
+++ b/akkeeper/src/main/scala/akkeeper/master/service/MonitoringService.scala
@@ -45,7 +45,7 @@ private[akkeeper] class MonitoringService(instanceStorage: InstanceStorage.Async
   private val launchTimeoutTasks: mutable.Map[InstanceId, Cancellable] = mutable.Map.empty
   private val deadInstances: mutable.Set[InstanceId] = mutable.Set.empty
 
-  override protected def trackedMessages: List[Class[_]] = List(classOf[TerminateInstance])
+  override protected def trackedMessages: Set[Class[_]] = Set(classOf[TerminateInstance])
 
   override def preStart(): Unit = {
     log.debug("Initializing Monitoring service")

--- a/akkeeper/src/main/scala/akkeeper/master/service/RequestTrackingService.scala
+++ b/akkeeper/src/main/scala/akkeeper/master/service/RequestTrackingService.scala
@@ -31,7 +31,7 @@ private[service] trait RequestTrackingService extends Actor with ActorLogging {
     currentServiceReceive getOrElse serviceReceive
   }
 
-  private def baseReceive: Receive = {
+  private def trackedMessagesReceive: Receive = {
     case request: WithRequestId if trackedMessages.contains(request.getClass) =>
       sendersById.put(request.requestId, SenderContext(sender(), None))
       getServiceReceive(request)
@@ -39,7 +39,7 @@ private[service] trait RequestTrackingService extends Actor with ActorLogging {
 
   protected def serviceReceive: Receive
 
-  protected def trackedMessages: List[Class[_]] = Nil
+  protected def trackedMessages: Set[Class[_]] = Set.empty
 
   protected def setOriginalSenderContext(id: RequestId, context: Any): Unit = {
     if (sendersById.contains(id)) {
@@ -75,10 +75,10 @@ private[service] trait RequestTrackingService extends Actor with ActorLogging {
 
   protected def become(newState: Receive): Unit = {
     currentServiceReceive = Some(newState)
-    context.become(baseReceive orElse newState)
+    context.become(trackedMessagesReceive orElse newState)
   }
 
   override def receive: Receive = {
-    baseReceive orElse serviceReceive
+    trackedMessagesReceive orElse serviceReceive
   }
 }


### PR DESCRIPTION
1. Simplify RequestId

2. Simplify operationFailedWriter

3. Simplify InstanceId

4. Rename RequestTrackingService.baseService -> RequestTrackingService.trackedMessagesReceive

5. Remove ".apply" for case classes while building AutoRequestIdFormat